### PR TITLE
面接日程の表示/登録/編集/削除機能の追加

### DIFF
--- a/app/assets/javascripts/interviews.coffee
+++ b/app/assets/javascripts/interviews.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -5,3 +5,11 @@
   display: inline-block;
   width: auto;
 }
+
+.button {
+  margin-left: 30px;
+}
+
+.text {
+  vertical-align: middle;
+}

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -13,3 +13,8 @@
 .text {
   vertical-align: middle;
 }
+
+textarea {
+  resize: vertical;
+  overflow: auto;
+}

--- a/app/assets/stylesheets/interviews.scss
+++ b/app/assets/stylesheets/interviews.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Interviews controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,8 +6,7 @@ class ApplicationController < ActionController::Base
     '/users'
   end
 
-  def current_user?
-    user = User.find(params[:user_id])
+  def current_user?(user)
     user == current_user
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,11 @@ class ApplicationController < ActionController::Base
     '/users'
   end
 
+  def current_user?
+    user = User.find(params[:user_id])
+    user == current_user
+  end
+
   protected
 
     def configure_permitted_parameters

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,0 +1,10 @@
+class InterviewsController < ApplicationController
+  def index
+  end
+
+  def new
+  end
+
+  def edit
+  end
+end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -7,7 +7,8 @@ class InterviewsController < ApplicationController
   end
 
   def new
-    if current_user?
+    user = User.find(params[:user_id])
+    if current_user?(user)
       @interview = current_user.interviews.build
     else
       flash[:danger] = "アクセスできません"

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,12 +1,28 @@
 class InterviewsController < ApplicationController
   def index
-    @user = User.find(params[:id])
+    @user = User.find(params[:user_id])
     @interviews = @user.interviews
   end
 
   def new
+    @interview = Interview.new
+  end
+
+  def create
+    @interview = current_user.interviews.build(interview_params)
+    if @interview.save
+      flash[:success] = "面接希望日時が作成されました"
+      redirect_to user_interviews_path
+    else
+      render 'interviews/new'
+    end
   end
 
   def edit
   end
+
+  private
+    def interview_params
+      params.require(:interview).permit(:schedule, :note)
+    end
 end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,14 +1,13 @@
 class InterviewsController < ApplicationController
+  before_action :set_user, only: [:index, :new, :create, :edit]
   before_action :correct_user, only: [:edit, :destroy, :update]
   before_action :authenticate_user!
   def index
-    @user = User.find(params[:user_id])
     @interviews = @user.interviews.order(schedule: :asc)
   end
 
   def new
-    user = User.find(params[:user_id])
-    if current_user?(user)
+    if current_user?(@user)
       @interview = current_user.interviews.build
     else
       flash[:danger] = "アクセスできません"
@@ -50,9 +49,12 @@ class InterviewsController < ApplicationController
       params.require(:interview).permit(:schedule, :note)
     end
 
-    def correct_user
+    def set_user
       @user = User.find(params[:user_id])
-      @interview = @user.interviews.find_by(id: params[:id])
+    end
+
+    def correct_user
+      @interview = current_user.interviews.find_by(id: params[:id])
       redirect_to root_url if @interview.nil?
     end
 

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,5 +1,7 @@
 class InterviewsController < ApplicationController
   def index
+    @user = User.find(params[:id])
+    @interviews = @user.interviews
   end
 
   def new

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -19,6 +19,17 @@ class InterviewsController < ApplicationController
   end
 
   def edit
+    @interview = Interview.find(params[:id])
+  end
+
+  def update
+    @interview = Interview.find(params[:id])
+    if @interview.update_attributes(interview_params)
+      flash[:success] = "面接希望日時を更新しました"
+      redirect_to user_interviews_path(current_user)
+    else
+      render 'edit'
+    end
   end
 
   private

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -30,7 +30,7 @@ class InterviewsController < ApplicationController
   end
 
   def update
-    if @interview.update_attributes(interview_params)
+    if @interview.update(interview_params)
       flash[:success] = "面接希望日時を更新しました"
       redirect_to user_interviews_path(current_user)
     else

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -32,6 +32,13 @@ class InterviewsController < ApplicationController
     end
   end
 
+  def destroy
+    @interview = current_user.interviews.find(params[:id])
+    @interview.destroy
+    flash[:success] = "面接希望日時を削除しました。"
+    redirect_to user_interviews_path(current_user)
+  end
+
   private
     def interview_params
       params.require(:interview).permit(:schedule, :note)

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,11 +1,18 @@
 class InterviewsController < ApplicationController
+  before_action :correct_user, only: [:edit, :destroy, :update]
+  before_action :authenticate_user!
   def index
     @user = User.find(params[:user_id])
     @interviews = @user.interviews
   end
 
   def new
-    @interview = Interview.new
+    if current_user?
+      @interview = current_user.interviews.build
+    else
+      flash[:danger] = "アクセスできません"
+      redirect_to user_interviews_path(current_user)
+    end
   end
 
   def create
@@ -19,11 +26,9 @@ class InterviewsController < ApplicationController
   end
 
   def edit
-    @interview = Interview.find(params[:id])
   end
 
   def update
-    @interview = Interview.find(params[:id])
     if @interview.update_attributes(interview_params)
       flash[:success] = "面接希望日時を更新しました"
       redirect_to user_interviews_path(current_user)
@@ -33,14 +38,20 @@ class InterviewsController < ApplicationController
   end
 
   def destroy
-    @interview = current_user.interviews.find(params[:id])
     @interview.destroy
     flash[:success] = "面接希望日時を削除しました。"
     redirect_to user_interviews_path(current_user)
   end
 
   private
+
     def interview_params
       params.require(:interview).permit(:schedule, :note)
     end
+
+    def correct_user
+      @interview = current_user.interviews.find_by(id: params[:id])
+      redirect_to root_url if @interview.nil?
+    end
+
 end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -3,7 +3,7 @@ class InterviewsController < ApplicationController
   before_action :authenticate_user!
   def index
     @user = User.find(params[:user_id])
-    @interviews = @user.interviews
+    @interviews = @user.interviews.order(schedule: :asc)
   end
 
   def new

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -51,7 +51,8 @@ class InterviewsController < ApplicationController
     end
 
     def correct_user
-      @interview = current_user.interviews.find_by(id: params[:id])
+      @user = User.find(params[:user_id])
+      @interview = @user.interviews.find_by(id: params[:id])
       redirect_to root_url if @interview.nil?
     end
 

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -21,7 +21,7 @@ class InterviewsController < ApplicationController
       flash[:success] = "面接希望日時が作成されました"
       redirect_to user_interviews_path
     else
-      render 'interviews/new'
+      render 'new'
     end
   end
 

--- a/app/helpers/interviews_helper.rb
+++ b/app/helpers/interviews_helper.rb
@@ -1,0 +1,2 @@
+module InterviewsHelper
+end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,0 +1,3 @@
+class Interview < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,4 +1,12 @@
 class Interview < ApplicationRecord
   enum status: { pending: 0, approved: 1, rejected: 2}
   belongs_to :user
+  validates :schedule, :status, :user_id, presence: true
+  validate :schedule_date_cannot_be_in_the_past
+
+  def schedule_date_cannot_be_in_the_past
+    if schedule.present? && schedule < DateTime.now
+      errors.add(:schedule, "can't be in the past")
+    end
+  end
 end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,3 +1,4 @@
 class Interview < ApplicationRecord
+  enum status: { pending: 0, approved: 1, rejected: 2}
   belongs_to :user
 end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,12 +1,6 @@
 class Interview < ApplicationRecord
   enum status: { pending: 0, approved: 1, rejected: 2}
   belongs_to :user
-  validates :schedule, :status, :user_id, presence: true
-  validate :schedule_date_cannot_be_in_the_past
-
-  def schedule_date_cannot_be_in_the_past
-    if schedule.present? && schedule < DateTime.now
-      errors.add(:schedule, "can't be in the past")
-    end
-  end
+  validates :status, :user_id, presence: true
+  validates :schedule, presence: true, schedule: { allow_blank: true }
 end

--- a/app/models/schedule_validator.rb
+++ b/app/models/schedule_validator.rb
@@ -1,0 +1,5 @@
+class ScheduleValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    record.errors.add(attribute, "can't be in the past") if value < DateTime.now
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   enum gender: { man: 0, woman: 1 }
-  has_many :interviews
+  has_many :interviews, dependent: :destroy
   validate :birthday_cannot_be_in_the_future
 
   def age

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   enum gender: { man: 0, woman: 1 }
+  has_many :interviews
 
   def age
     date_format = "%Y%m%d"

--- a/app/views/interviews/_form.html.erb
+++ b/app/views/interviews/_form.html.erb
@@ -1,0 +1,29 @@
+<%= form_for(@interview, url: yield(:url)) do |f| %>
+
+  <div class="form-group">
+    <%= f.label :schedule, "開始時間" %>
+    <%= raw sprintf(
+                f.datetime_select(
+                    :schedule,
+                    {
+                        use_month_numbers: true,
+                        start_year: Time.now.year,
+                        end_year: (Time.now.year + 5),
+                        minute_step: 5,
+                        date_separator: '%s',
+                        datetime_separator: '%s',
+                        time_separator: '%s',
+                    },
+                    { class: "form-control bootstrap-selector" }
+                ),
+                "年 ", "月 ", "日 ", "時 ",) + "分" %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :note, "備考欄" %>
+    <%= f.text_area :note, class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <%= f.submit yield(:button_text), class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/interviews/_form.html.erb
+++ b/app/views/interviews/_form.html.erb
@@ -1,4 +1,5 @@
 <%= form_for(@interview, url: yield(:url)) do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
 
   <div class="form-group">
     <%= f.label :schedule, "開始時間" %>

--- a/app/views/interviews/_form.html.erb
+++ b/app/views/interviews/_form.html.erb
@@ -3,21 +3,7 @@
 
   <div class="form-group">
     <%= f.label :schedule, "開始時間" %>
-    <%= raw sprintf(
-                f.datetime_select(
-                    :schedule,
-                    {
-                        use_month_numbers: true,
-                        start_year: Time.now.year,
-                        end_year: (Time.now.year + 5),
-                        minute_step: 5,
-                        date_separator: '%s',
-                        datetime_separator: '%s',
-                        time_separator: '%s',
-                    },
-                    { class: "form-control bootstrap-selector" }
-                ),
-                "年 ", "月 ", "日 ", "時 ",) + "分" %>
+    <%= f.datetime_field :schedule, class: "form-control bootstrap-selector" %>
   </div>
 
   <div class="form-group">

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>Interviews#edit</h1>
+<p>Find me in app/views/interviews/edit.html.erb</p>

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -1,2 +1,4 @@
-<h1>Interviews#edit</h1>
-<p>Find me in app/views/interviews/edit.html.erb</p>
+<% provide(:url, interview_path) %>
+<% provide(:button_text, "更新") %>
+<h1>面接日程編集</h1>
+<%= render 'form' %>

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -1,4 +1,4 @@
-<% provide(:url, interview_path) %>
+<% provide(:url, user_interview_path) %>
 <% provide(:button_text, "更新") %>
 <h1>面接日程編集</h1>
 <%= render 'form' %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Interviews#index</h1>
+<p>Find me in app/views/interviews/index.html.erb</p>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,4 +1,7 @@
-<h1><%= "#{@user.name}さんの面接一覧" %></h1>
+<h1>
+  <span class="text"><%= "#{@user.name}さんの面接一覧" %></span>
+  <span class="button"><%= link_to "新規面接作成", new_interview_path, class: "btn btn-primary" %></span>
+</h1>
 <table class="table table-bordered table-hover">
   <thead>
     <tr>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,6 +1,6 @@
 <h1>
   <span class="text"><%= "#{@user.name}さんの面接一覧" %></span>
-  <span class="button"><%= link_to "新規面接作成", new_user_interview_path, class: "btn btn-primary" %></span>
+  <span class="button"><%= link_to "新規面接作成", new_user_interview_path(@user), class: "btn btn-primary" %></span>
 </h1>
 <table class="table table-bordered table-hover">
   <thead>
@@ -17,8 +17,8 @@
         <td><div class="text-center"><%= interview.schedule.strftime('%Y年%m月%d日 %H:%M') %></div></td>
         <td><div class="text-center"><%= interview.status %></div></td>
         <td><div class="text-center"><%= interview.note %></div></td>
-        <td><div class="text-center"><%= link_to "編集",  edit_interview_path(interview.id), class: "btn btn-info"%></div></td>
-        <td><div class="text-center"><%= link_to "削除", interview_path(interview), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-danger" %></div></td>
+        <td><div class="text-center"><%= link_to "編集",  edit_user_interview_path(id: interview, user_id: @user), class: "btn btn-info"%></div></td>
+        <td><div class="text-center"><%= link_to "削除", user_interview_path(id: interview, user_id: @user), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-danger" %></div></td>
       </tr>
     </tbody>
   <% end %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -18,7 +18,7 @@
         <td><div class="text-center"><%= interview.status %></div></td>
         <td><div class="text-center"><%= interview.note %></div></td>
         <td><div class="text-center"><%= link_to "編集",  edit_interview_path(interview.id), class: "btn btn-info"%></div></td>
-        <td><div class="text-center"><%= link_to "削除", interview, method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-danger" %></div></td>
+        <td><div class="text-center"><%= link_to "削除", interview_path(interview), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-danger" %></div></td>
       </tr>
     </tbody>
   <% end %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -14,7 +14,7 @@
   <% @interviews.each do |interview| %>
     <tbody>
       <tr>
-        <td><div class="text-center"><%= interview.schedule %></div></td>
+        <td><div class="text-center"><%= interview.schedule.strftime('%Y年%m月%d日 %H:%M') %></div></td>
         <td><div class="text-center"><%= interview.status %></div></td>
         <td><div class="text-center"><%= interview.note %></div></td>
         <td><div class="text-center"><%= link_to "編集",  edit_interview_path(interview.id), class: "btn btn-info"%></div></td>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,6 +1,6 @@
 <h1>
   <span class="text"><%= "#{@user.name}さんの面接一覧" %></span>
-  <span class="button"><%= link_to "新規面接作成", new_interview_path, class: "btn btn-primary" %></span>
+  <span class="button"><%= link_to "新規面接作成", new_user_interview_path, class: "btn btn-primary" %></span>
 </h1>
 <table class="table table-bordered table-hover">
   <thead>
@@ -17,7 +17,7 @@
         <td><div class="text-center"><%= interview.schedule %></div></td>
         <td><div class="text-center"><%= interview.status %></div></td>
         <td><div class="text-center"><%= interview.note %></div></td>
-        <td><div class="text-center"><%= link_to "編集",  edit_interview_path, class: "btn btn-info"%></div></td>
+        <td><div class="text-center"><%= link_to "編集",  edit_interview_path(interview.id), class: "btn btn-info"%></div></td>
         <td><div class="text-center"><%= link_to "削除", interview, method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-danger" %></div></td>
       </tr>
     </tbody>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,2 +1,22 @@
-<h1>Interviews#index</h1>
-<p>Find me in app/views/interviews/index.html.erb</p>
+<h1><%= "#{@user.name}さんの面接一覧" %></h1>
+<table class="table table-bordered table-hover">
+  <thead>
+    <tr>
+      <th><div class="text-center">面接開始時間</div></th>
+      <th><div class="text-center">承認状態</div></th>
+      <th><div class="text-center">備考欄</div></th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+  <% @interviews.each do |interview| %>
+    <tbody>
+      <tr>
+        <td><div class="text-center"><%= interview.schedule %></div></td>
+        <td><div class="text-center"><%= interview.status %></div></td>
+        <td><div class="text-center"><%= interview.note %></div></td>
+        <td><div class="text-center"><%= link_to "編集",  edit_interview_path, class: "btn btn-info"%></div></td>
+        <td><div class="text-center"><%= link_to "削除", interview, method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-danger" %></div></td>
+      </tr>
+    </tbody>
+  <% end %>
+</table>

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Interviews#new</h1>
+<p>Find me in app/views/interviews/new.html.erb</p>

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -1,30 +1,4 @@
+<% provide(:url, user_interviews_path) %>
+<% provide(:button_text, "作成") %>
 <h1>新規面接作成</h1>
-<%= form_for(@interview, url: user_interviews_path) do |f| %>
-
-  <div class="form-group">
-    <%= f.label :schedule, "開始時間" %>
-    <%= raw sprintf(
-                f.datetime_select(
-                    :schedule,
-                    {
-                        use_month_numbers: true,
-                        start_year: Time.now.year,
-                        end_year: (Time.now.year + 5),
-                        minute_step: 5,
-                        date_separator: '%s',
-                        datetime_separator: '%s',
-                        time_separator: '%s',
-                    },
-                    { class: "form-control bootstrap-selector" }
-                ),
-                "年 ", "月 ", "日 ", "時 ",) + "分" %>
-  </div>
-
-  <div class="form-group">
-    <%= f.label :note, "備考欄" %>
-    <%= f.text_area :note, class: "form-control" %>
-  </div>
-  <div class="form-group">
-    <%= f.submit "作成", class: "btn btn-primary" %>
-  </div>
-<% end %>
+<%= render 'form' %>

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -1,2 +1,30 @@
-<h1>Interviews#new</h1>
-<p>Find me in app/views/interviews/new.html.erb</p>
+<h1>新規面接作成</h1>
+<%= form_for(@interview, url: user_interviews_path) do |f| %>
+
+  <div class="form-group">
+    <%= f.label :schedule, "開始時間" %>
+    <%= raw sprintf(
+                f.datetime_select(
+                    :schedule,
+                    {
+                        use_month_numbers: true,
+                        start_year: Time.now.year,
+                        end_year: (Time.now.year + 5),
+                        minute_step: 5,
+                        date_separator: '%s',
+                        datetime_separator: '%s',
+                        time_separator: '%s',
+                    },
+                    { class: "form-control bootstrap-selector" }
+                ),
+                "年 ", "月 ", "日 ", "時 ",) + "分" %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :note, "備考欄" %>
+    <%= f.text_area :note, class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <%= f.submit "作成", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,8 +33,11 @@
       </nav>
     </header>
     <div class="container">
-      <p class="notice"><%= notice %></p>
-      <p class="alert"><%= alert %></p>
+      <% flash.each do |message_type, message| %>
+        <% message_type = "info" if message_type == "notice" %>
+        <% message_type = "danger" if message_type == "alert" %>
+        <%= content_tag(:div, message, class: "alert alert-#{message_type}") %>
+      <% end %>
       <%= yield %>
     </div>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
           <% if user_signed_in? %>
             <ul class="nav navbar-nav">
               <li><%= link_to "プロフィール", edit_user_registration_path %></li>
-              <li><%= link_to "自分の面接一覧", "#" %></li>
+              <li><%= link_to "自分の面接一覧", user_interviews_path(current_user) %></li>
               <li><%= link_to "メール", "#" %></li>
               <li><%= link_to "ログアウト", destroy_user_session_path, method: :delete %></li>
             </ul>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div class="alert alert-danger">
+    <ul>
+      <% object.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,5 +27,6 @@ module ENavigator
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+    config.time_zone = 'Tokyo'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,4 @@
 Rails.application.routes.draw do
-  get 'interviews/index'
-
-  get 'interviews/new'
-
-  get 'interviews/edit'
-
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   devise_for :users
   devise_scope :user do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   devise_scope :user do
     root :to => "devise/sessions#new"
   end
-  resources :users do
-    resources :interviews, shallow: true
+  resources :users, only: [:index] do
+    resources :interviews
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,18 @@
 Rails.application.routes.draw do
+  get 'interviews/index'
+
+  get 'interviews/new'
+
+  get 'interviews/edit'
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   devise_for :users
   devise_scope :user do
     root :to => "devise/sessions#new"
   end
-  resources :users, only: [:index]
+  resources :users, only: [:index] do
+    member do
+      resources :interviews
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,9 +4,7 @@ Rails.application.routes.draw do
   devise_scope :user do
     root :to => "devise/sessions#new"
   end
-  resources :users, only: [:index] do
-    member do
-      resources :interviews
-    end
+  resources :users do
+    resources :interviews, shallow: true
   end
 end

--- a/db/migrate/20181006154128_create_interviews.rb
+++ b/db/migrate/20181006154128_create_interviews.rb
@@ -1,0 +1,14 @@
+class CreateInterviews < ActiveRecord::Migration[5.1]
+  def change
+    create_table :interviews do |t|
+      t.datetime :schedule, null: false
+      t.text :note
+      t.integer :status, default: 0
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :interviews, [:user_id, :schedule]
+    add_index :interviews, [:status]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181004194327) do
+ActiveRecord::Schema.define(version: 20181006154128) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "interviews", force: :cascade do |t|
+    t.datetime "schedule", null: false
+    t.text "note"
+    t.integer "status", default: 0
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["status"], name: "index_interviews_on_status"
+    t.index ["user_id", "schedule"], name: "index_interviews_on_user_id_and_schedule"
+    t.index ["user_id"], name: "index_interviews_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -31,4 +43,5 @@ ActiveRecord::Schema.define(version: 20181004194327) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "interviews", "users"
 end


### PR DESCRIPTION
後半第1章の作業が完了いたしましたので、レビューよろしくお願いいたします。:bow:
URL: https://e-navigator-shoynoi.herokuapp.com/

やりたかったこと
---
- 面接日程の表示/登録/編集/削除機能の追加

やったこと
----
- Interviewモデルの作成
    - schedule:datetime note:text status:integer user_id:referencesとしてinterviewsテーブルを作成
- `users/:id/interviews`でユーザー毎の面接日程の一覧を時刻の昇順で表示
- 面接日程の新規登録ページを作成し、面接開始日時と備考欄の登録機能を追加
    - 過去の日付はバリデーションで弾くようにしています。
    - 不正な日付を選択できないようにdatetime_fieldを使用しました。
    - ユーザーを削除した場合関連する面接日程も削除するようにしました。
- 面接日程の編集ページを作成し、登録した日程の編集機能を追加
- 登録した面接日程の削除機能を追加
- タイムゾーンの影響でバリデーションを抜けてしまうことがあるため、タイムゾーンを日本時間に変更
- 他のユーザーの面接日程の登録/編集/更新/削除ができないように認可機能を追加

動作確認方法
---
- [ ] ログイン後、自分の面接一覧を押下、新規面接作成ボタンから日時、備考欄を記入し、作成すると面接日程が登録され、面接一覧ページへリダイレクト
- [ ] 過去の日付を登録するとエラーが表示
- [ ] 面接一覧ページ内の登録されている日程から編集ボタンを押下、日付や備考欄を変更し、更新すると面接日程が更新される
- [ ] 面接一覧ページ内の登録されている日程から削除ボタンを押下、OKを選択すると日程が削除される
- [ ] 複数の面接日程を登録すると、面接一覧ページでは時刻の昇順で日程が表示される
- [ ] 他のユーザーの面接日程作成ページ、更新ページにアクセスすると自分の面接一覧ページへリダイレクト

