### PR TITLE
面接日程の承認/却下機能の追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
-
-  def current_user?(user)
-    user == current_user
-  end
+  include ApplicationHelper
 
   protected
 

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -44,6 +44,17 @@ class InterviewsController < ApplicationController
     redirect_to user_interviews_path(current_user)
   end
 
+  def approve
+    @interview = Interview.find(params[:id])
+    @user = User.find(params[:user_id])
+    if @interview.confirm_interview(@user)
+      flash[:success] = "面接希望日時を承認しました"
+      redirect_to user_interviews_path(@user)
+    else
+      render 'index'
+    end
+  end
+
   private
 
     def interview_params

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -10,16 +10,14 @@ class InterviewsController < ApplicationController
     if current_user?(@user)
       @interview = current_user.interviews.build
     else
-      flash[:danger] = "アクセスできません"
-      redirect_to user_interviews_path(current_user)
+      redirect_to user_interviews_path(current_user), flash: { danger: "アクセスできません" }
     end
   end
 
   def create
     @interview = current_user.interviews.build(interview_params)
     if @interview.save
-      flash[:success] = "面接希望日時が作成されました"
-      redirect_to user_interviews_path
+      redirect_to user_interviews_path, flash: { success: "面接希望日時が作成されました" }
     else
       render 'new'
     end
@@ -30,8 +28,7 @@ class InterviewsController < ApplicationController
 
   def update
     if @interview.update(interview_params)
-      flash[:success] = "面接希望日時を更新しました"
-      redirect_to user_interviews_path(current_user)
+      redirect_to user_interviews_path(current_user), flash: { success: "面接希望日時を更新しました" }
     else
       render 'edit'
     end
@@ -39,8 +36,7 @@ class InterviewsController < ApplicationController
 
   def destroy
     @interview.destroy
-    flash[:success] = "面接希望日時を削除しました。"
-    redirect_to user_interviews_path(current_user)
+    redirect_to user_interviews_path(current_user), flash: { success: "面接希望日時を削除しました" }
   end
 
   def approve
@@ -49,11 +45,9 @@ class InterviewsController < ApplicationController
       @user.interviews.where.not(id: @interview).each do |interview|
         interview.update_attribute(:status, "rejected")
       end
-      flash[:success] = "面接希望日時を承認しました"
-      redirect_to user_interviews_path(@user)
+      redirect_to user_interviews_path(@user), flash: { success: "面接希望日時を承認しました" }
     else
-      flash[:danger] = "過去の日付は承認できません"
-      redirect_to user_interviews_path(@user)
+      redirect_to user_interviews_path(@user), flash: { danger: "過去の日付は承認できません" }
     end
   end
 

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -42,9 +42,7 @@ class InterviewsController < ApplicationController
   def approve
     @interview = Interview.find(params[:id])
     if @interview.update(status: "approved")
-      @user.interviews.where.not(id: @interview).each do |interview|
-        interview.update_attribute(:status, "rejected")
-      end
+      @user.interviews.where.not(id: @interview).update_all(status: "rejected")
       redirect_to user_interviews_path(@user), flash: { success: "面接希望日時を承認しました" }
     else
       redirect_to user_interviews_path(@user), flash: { danger: "過去の日付は承認できません" }

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,6 +1,6 @@
 class InterviewsController < ApplicationController
-  before_action :set_user, only: [:index, :new, :create, :edit]
-  before_action :correct_user, only: [:edit, :destroy, :update, :approve]
+  before_action :set_user, only: [:index, :new, :create, :edit, :approve]
+  before_action :correct_user, only: [:edit, :destroy, :update]
   before_action :authenticate_user!
   def index
     @interviews = @user.interviews.order(schedule: :asc)
@@ -44,6 +44,7 @@ class InterviewsController < ApplicationController
   end
 
   def approve
+    @interview = Interview.find(params[:id])
     if @interview.update(status: "approved")
       @user.interviews.where.not(id: @interview).each do |interview|
         interview.update_attribute(:status, "rejected")

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,5 +1,5 @@
 class InterviewsController < ApplicationController
-  before_action :correct_user, only: [:edit, :destroy, :update]
+  before_action :correct_user, only: [:edit, :destroy, :update, :approve]
   before_action :authenticate_user!
   def index
     @user = User.find(params[:user_id])
@@ -45,13 +45,15 @@ class InterviewsController < ApplicationController
   end
 
   def approve
-    @interview = Interview.find(params[:id])
-    @user = User.find(params[:user_id])
-    if @interview.confirm_interview(@user)
+    if @interview.update_attributes(status: "approved")
+      @user.interviews.where.not(id: @interview).each do |interview|
+        interview.update_attribute(:status, "rejected")
+      end
       flash[:success] = "面接希望日時を承認しました"
       redirect_to user_interviews_path(@user)
     else
-      render 'index'
+      flash[:danger] = "過去の日付は承認できません"
+      redirect_to user_interviews_path(@user)
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,6 @@
 module ApplicationHelper
+
+  def current_user?(user)
+    user == current_user
+  end
 end

--- a/app/helpers/interviews_helper.rb
+++ b/app/helpers/interviews_helper.rb
@@ -1,2 +1,6 @@
 module InterviewsHelper
+
+  def confirmed?(interview)
+    interview.user_id == current_user.id && interview.status != 'pending'
+  end
 end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -4,6 +4,10 @@ class Interview < ApplicationRecord
   validates :schedule, :status, :user_id, presence: true
   validate :schedule_date_cannot_be_in_the_past
 
+  def confirm_interview(user)
+    user.interviews.where.not(id: self).map(&:rejected!) if approved!
+  end
+
   def schedule_date_cannot_be_in_the_past
     if schedule.present? && schedule < DateTime.now
       errors.add(:schedule, "can't be in the past")

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -4,10 +4,6 @@ class Interview < ApplicationRecord
   validates :schedule, :status, :user_id, presence: true
   validate :schedule_date_cannot_be_in_the_past
 
-  def confirm_interview(user)
-    user.interviews.where.not(id: self).map(&:rejected!) if approved!
-  end
-
   def customized_schedule_format
     schedule.strftime('%Y年%m月%d日 %H:%M')
   end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -8,6 +8,10 @@ class Interview < ApplicationRecord
     user.interviews.where.not(id: self).map(&:rejected!) if approved!
   end
 
+  def customized_schedule_format
+    schedule.strftime('%Y年%m月%d日 %H:%M')
+  end
+
   def schedule_date_cannot_be_in_the_past
     if schedule.present? && schedule < DateTime.now
       errors.add(:schedule, "can't be in the past")

--- a/app/views/interviews/_interviews_others.html.erb
+++ b/app/views/interviews/_interviews_others.html.erb
@@ -13,7 +13,13 @@
     <tr>
       <td><div class="text-center"><%= interview.schedule.strftime('%Y年%m月%d日 %H:%M') %></div></td>
       <td><div class="text-center"><%= interview.note %></div></td>
-      <td><div class="text-center"><%= link_to "承認する", "#", data: { confirm: "#{interview.schedule.strftime('%Y年%m月%d日 %H:%M')}でよろしいですか？" }, class: "btn btn-success" %></div></td>
+      <td><div class="text-center">
+        <%= link_to "承認する",
+           approve_user_interview_path(id: interview, user_id: @user),
+           method: :patch,
+           data: { confirm: "#{interview.schedule.strftime('%Y年%m月%d日 %H:%M')}でよろしいですか？" },
+           class: "btn btn-success" %>
+      </div></td>
     </tr>
     </tbody>
   <% end %>

--- a/app/views/interviews/_interviews_others.html.erb
+++ b/app/views/interviews/_interviews_others.html.erb
@@ -1,5 +1,5 @@
 <h1><%= "#{@user.name}さんの面接希望一覧" %></h1>
-<h2>現在の面接日程: </h2>
+<h2>現在の面接日程: <%= @interviews.find_by(status: "approved").try(:customized_schedule_format) %> </h2>
 <table class="table table-bordered table-hover">
   <thead>
   <tr>
@@ -11,13 +11,13 @@
   <% @interviews.each do |interview| %>
     <tbody>
     <tr>
-      <td><div class="text-center"><%= interview.schedule.strftime('%Y年%m月%d日 %H:%M') %></div></td>
+      <td><div class="text-center"><%= interview.customized_schedule_format %></div></td>
       <td><div class="text-center"><%= interview.note %></div></td>
       <td><div class="text-center">
         <%= link_to "承認する",
            approve_user_interview_path(id: interview, user_id: @user),
            method: :patch,
-           data: { confirm: "#{interview.schedule.strftime('%Y年%m月%d日 %H:%M')}でよろしいですか？" },
+           data: { confirm: "#{interview.customized_schedule_format}でよろしいですか？" },
            class: "btn btn-success" %>
       </div></td>
     </tr>

--- a/app/views/interviews/_interviews_others.html.erb
+++ b/app/views/interviews/_interviews_others.html.erb
@@ -1,0 +1,20 @@
+<h1><%= "#{@user.name}さんの面接希望一覧" %></h1>
+<h2>現在の面接日程: </h2>
+<table class="table table-bordered table-hover">
+  <thead>
+  <tr>
+    <th><div class="text-center">面接開始時間</div></th>
+    <th><div class="text-center">備考欄</div></th>
+    <th colspan="3"></th>
+  </tr>
+  </thead>
+  <% @interviews.each do |interview| %>
+    <tbody>
+    <tr>
+      <td><div class="text-center"><%= interview.schedule.strftime('%Y年%m月%d日 %H:%M') %></div></td>
+      <td><div class="text-center"><%= interview.note %></div></td>
+      <td><div class="text-center"><%= link_to "承認する", "#", data: { confirm: "#{interview.schedule.strftime('%Y年%m月%d日 %H:%M')}でよろしいですか？" }, class: "btn btn-success" %></div></td>
+    </tr>
+    </tbody>
+  <% end %>
+</table>

--- a/app/views/interviews/_interviews_self.html.erb
+++ b/app/views/interviews/_interviews_self.html.erb
@@ -1,0 +1,25 @@
+<h1>
+  <span class="text"><%= "#{@user.name}さんの面接一覧" %></span>
+  <span class="button"><%= link_to "新規面接作成", new_user_interview_path(@user), class: "btn btn-primary" %></span>
+</h1>
+<table class="table table-bordered table-hover">
+  <thead>
+  <tr>
+    <th><div class="text-center">面接開始時間</div></th>
+    <th><div class="text-center">承認状態</div></th>
+    <th><div class="text-center">備考欄</div></th>
+    <th colspan="3"></th>
+  </tr>
+  </thead>
+  <% @interviews.each do |interview| %>
+    <tbody>
+    <tr>
+      <td><div class="text-center"><%= interview.schedule.strftime('%Y年%m月%d日 %H:%M') %></div></td>
+      <td><div class="text-center"><%= interview.status %></div></td>
+      <td><div class="text-center"><%= interview.note %></div></td>
+      <td><div class="text-center"><%= link_to "編集",  edit_user_interview_path(id: interview, user_id: @user), class: "btn btn-info"%></div></td>
+      <td><div class="text-center"><%= link_to "削除", user_interview_path(id: interview, user_id: @user), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-danger" %></div></td>
+    </tr>
+    </tbody>
+  <% end %>
+</table>

--- a/app/views/interviews/_interviews_self.html.erb
+++ b/app/views/interviews/_interviews_self.html.erb
@@ -14,7 +14,7 @@
   <% @interviews.each do |interview| %>
     <tbody>
     <tr>
-      <td><div class="text-center"><%= interview.schedule.strftime('%Y年%m月%d日 %H:%M') %></div></td>
+      <td><div class="text-center"><%= interview.customized_schedule_format %></div></td>
       <td><div class="text-center"><%= interview.status %></div></td>
       <td><div class="text-center"><%= interview.note %></div></td>
       <td><div class="text-center"><%= link_to "編集",  edit_user_interview_path(id: interview, user_id: @user), class: "btn btn-info #{"disabled" if confirmed?(interview)}"%></div></td>

--- a/app/views/interviews/_interviews_self.html.erb
+++ b/app/views/interviews/_interviews_self.html.erb
@@ -17,8 +17,8 @@
       <td><div class="text-center"><%= interview.schedule.strftime('%Y年%m月%d日 %H:%M') %></div></td>
       <td><div class="text-center"><%= interview.status %></div></td>
       <td><div class="text-center"><%= interview.note %></div></td>
-      <td><div class="text-center"><%= link_to "編集",  edit_user_interview_path(id: interview, user_id: @user), class: "btn btn-info"%></div></td>
-      <td><div class="text-center"><%= link_to "削除", user_interview_path(id: interview, user_id: @user), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-danger" %></div></td>
+      <td><div class="text-center"><%= link_to "編集",  edit_user_interview_path(id: interview, user_id: @user), class: "btn btn-info #{"disabled" if confirmed?(interview)}"%></div></td>
+      <td><div class="text-center"><%= link_to "削除", user_interview_path(id: interview, user_id: @user), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-danger #{"disabled" if confirmed?(interview)}" %></div></td>
     </tr>
     </tbody>
   <% end %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,25 +1,5 @@
-<h1>
-  <span class="text"><%= "#{@user.name}さんの面接一覧" %></span>
-  <span class="button"><%= link_to "新規面接作成", new_user_interview_path(@user), class: "btn btn-primary" %></span>
-</h1>
-<table class="table table-bordered table-hover">
-  <thead>
-    <tr>
-      <th><div class="text-center">面接開始時間</div></th>
-      <th><div class="text-center">承認状態</div></th>
-      <th><div class="text-center">備考欄</div></th>
-      <th colspan="3"></th>
-    </tr>
-  </thead>
-  <% @interviews.each do |interview| %>
-    <tbody>
-      <tr>
-        <td><div class="text-center"><%= interview.schedule.strftime('%Y年%m月%d日 %H:%M') %></div></td>
-        <td><div class="text-center"><%= interview.status %></div></td>
-        <td><div class="text-center"><%= interview.note %></div></td>
-        <td><div class="text-center"><%= link_to "編集",  edit_user_interview_path(id: interview, user_id: @user), class: "btn btn-info"%></div></td>
-        <td><div class="text-center"><%= link_to "削除", user_interview_path(id: interview, user_id: @user), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-danger" %></div></td>
-      </tr>
-    </tbody>
-  <% end %>
-</table>
+<% if current_user?(@user) %>
+  <%= render 'interviews/interviews_self' %>
+<% else %>
+  <%= render 'interviews/interviews_others' %>
+<% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -19,7 +19,7 @@
         <td><div class="text-center"><%= user.age if user.birthday.present? %></div></td>
         <td><div class="text-center"><%= user.gender %></div></td>
         <td><div class="text-center"><%= user.school %></div></td>
-        <td><div class="text-center"><%=  %></div></td>
+        <td><div class="text-center"><%= user.interviews.find_by(status: "approved").try(:customized_schedule_format) %></div></td>
         <td><div class="text-center"><%= link_to "面接一覧", user_interviews_path(user), class: "btn btn-info" %></div></td>
       </tr>
     </tbody>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -20,7 +20,7 @@
         <td><div class="text-center"><%= user.gender %></div></td>
         <td><div class="text-center"><%= user.school %></div></td>
         <td><div class="text-center"><%=  %></div></td>
-        <td><div class="text-center"></div></td>
+        <td><div class="text-center"><%= link_to "面接一覧", user_interviews_path(user), class: "btn btn-info" %></div></td>
       </tr>
     </tbody>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,10 @@ Rails.application.routes.draw do
     root :to => "users#root"
   end
   resources :users, only: [:index] do
-    resources :interviews
+    resources :interviews do
+      member do
+        patch :approve
+      end
+    end
   end
 end


### PR DESCRIPTION
後半第2章の課題が完了しました。

やりたかったこと
---
- ユーザーが他のユーザーの面接日程を承認/却下する機能の追加

やったこと
----
- app/views/interviews/index.html.erb内で自身と他のユーザーで面接日程の表示を分けるパーシャルを作成
- interviews#approveを追加、面接日程を承認/他の日程を却下する機能を作成
- 面接希望日が承認/却下された場合、その日程の編集/削除リンクを無効にする
- scheduleを表示するフォーマットをinterview.rbに定義し_interviews_others.html.erbで承認された面接日時を表示


動作確認方法
---
- [ ] ユーザーを2人作成、一方で有効な面接希望日を登録しログアウト、もう一方でログインするとユーザー一覧ページに自身以外のユーザーが表示されており、面接一覧ボタンが表示される。
- [ ] 面接一覧ボタンを押下すると、ユーザーの面接希望日一覧が表示
- [ ] 有効な希望日の承認するボタンを押下すると、希望日が承認され、"面接希望日時を承認しました"とflashが表示
- [ ] すでに過ぎてしまっている日時を承認すると、"過去の日付は承認できません"をエラーが表示
- [ ] 現在承認されている面接日時面接希望一覧ページに表示

レビューよろしくおねがいします。:bow: